### PR TITLE
chore: ignore git logs for markdownlint

### DIFF
--- a/notebooks/entropic-symbolic-society/.pre-commit-config.yaml
+++ b/notebooks/entropic-symbolic-society/.pre-commit-config.yaml
@@ -32,7 +32,13 @@ repos:
       - id: flake8
         args:
           - --max-line-length=120
-          - --extend-ignore=E501,W503,B950
+          - --extend-ignore=E203,E501,W503,B950
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.9.2
+    hooks:
+      - id: markdownlint-cli2
+        exclude: "^\\.git/"
 
 # Ignore global para “ruídos”
 exclude: |


### PR DESCRIPTION
## Summary
- ensure markdownlint skips `.git` internals
- align flake8 config with Black's E203 spacing style

## Testing
- `pre-commit run --all-files --config notebooks/entropic-symbolic-society/.pre-commit-config.yaml` *(fails: markdownlint-cli2)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3cd779148330b7a3526fbdbc473d