### PR TITLE
Ignore Git metadata during markdown linting

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+.git
+METADATA_ZENODO_PATCH_*.md
+README_PATCH_*.md


### PR DESCRIPTION
## Summary
- avoid markdownlint scanning Git internals or temporary patch files

## Testing
- `pre-commit run --files .markdownlintignore` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `npx -y markdownlint-cli2 "**/*.md"` *(fails: various markdownlint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3f5661348330b37b8b52708ee882