### PR TITLE
Ignore git directory and patch markdown files

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+.git/
+*_PATCH_*.md


### PR DESCRIPTION
## Summary
- prevent markdownlint from scanning internal `.git` logs
- skip linting of generated `*_PATCH_*.md` files

## Testing
- `pre-commit run --all-files` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4107047c8330a21d94c6a068040f