### PR TITLE
ci(md): temporarily soften markdownlint

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,23 +1,30 @@
 {
   "config": {
-    "MD007": {"indent": 2},
+    "default": true,
+
+    "MD007": { "indent": 2 },
     "MD010": false,
-    "MD012": {"maximum": 2},
-    "MD013": false,
-    "MD026": false,
-    "MD034": false
+    "MD012": { "maximum": 2 },
+
+    "MD013": false,   // line-length (temporariamente desativado)
+    "MD025": false,   // múltiplos H1 (longos manuscritos)
+    "MD029": false,   // prefixo de listas numeradas
+    "MD024": false,   // headings duplicados
+    "MD001": false,   // incremento de heading
+    "MD033": false,   // inline HTML
+    "MD041": false,   // primeira linha deve ser H1
+
+    "MD022": { "lines_above": 1, "lines_below": 1 },
+    "MD032": true,
+    "MD040": true     // manter exigência de linguagem em code fences (vamos auto-fixar)
   },
   "ignores": [
     "**/.git/**",
     "**/node_modules/**",
-    "__broken__/**",
     ".attic/**",
     ".safety/**",
-    "docs/**",
-    "notebooks/**",
-    "papers/**",
     "**/* 2.*",
-    "**/*.bak*",
+    "**/*.bak.*",
     "**/CHANGELOG_PATCH_*",
     "**/METADATA_ZENODO_PATCH_*",
     "**/README_PATCH*.md"

--- a/.safety/status-md-1756156363.txt
+++ b/.safety/status-md-1756156363.txt
@@ -1,0 +1,2 @@
+## work
+?? .safety/status-md-1756156363.txt

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Meta-repositório do projeto Psiquiatria Computacional‑Simbólica (PCS).
 git clone https://github.com/agourakis82/pcs-meta-repo
 cd pcs-meta-repo
 pip install -r requirements.txt
-```
+```text
 
 ## Cite this work
 

--- a/REPO_AUDIT_REPORT.md
+++ b/REPO_AUDIT_REPORT.md
@@ -50,14 +50,14 @@
       4 patch
       4 bst
       3 svg
-```
+```text
 
 ## Duplicate files (sha256 snippet)
 
 ```text
 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b  ./.safety/20250825-152706/staged.patch
 ...
-```
+```text
 
 ## Actions
 

--- a/docs/README_MASTER.md
+++ b/docs/README_MASTER.md
@@ -45,7 +45,7 @@
 /papers          → NHB manuscript & assets
 /curriculum      → syllabus & teaching material
 /figures, /data  → assets (use LFS)
-```
+```text
 
 ---
 

--- a/notebooks/entropic-symbolic-society/NHB_Symbolic_Mainfold/README.md
+++ b/notebooks/entropic-symbolic-society/NHB_Symbolic_Mainfold/README.md
@@ -52,7 +52,7 @@ Outputs (CSV, NPY, PNG) are stored in `data/` and `results/` for reproducibility
 
 ## 🗂 Directory Structure
 
-```
+```text
 NHB_Symbolic_Mainfold/
 ├── data/                      # Input datasets, intermediate and final outputs
 │   └── raw/                   # Raw files from OSF (SWOW-EN, cueStats, etc.)
@@ -65,7 +65,7 @@ NHB_Symbolic_Mainfold/
 ├── supplementary.tex           # NHB supplementary material
 ├── requirements.txt            # Reproducible environment specification
 └── README.md                   # This document
-```
+```text
 
 ---
 
@@ -74,20 +74,20 @@ NHB_Symbolic_Mainfold/
 1. **Clone the repository** (or download this subfolder).
 
 2. **Download raw data** from OSF DOI [10.17605/OSF.IO/2AQP7](https://doi.org/10.17605/OSF.IO/2AQP7) and place files in:
-```
+```text
 data/raw/
-```
+```text
 
 3. **Create and activate environment:**
 ```bash
 bash scripts/reset_env.sh
 conda activate entropic-symbolic-mainfold   # or source .venv/bin/activate if using venv
-```
+```text
 
 4. **Launch JupyterLab:**
 ```bash
 jupyter lab
-```
+```text
 
 5. **Run notebooks** in numerical order (01 → 06).
 
@@ -111,7 +111,7 @@ If you use this package, please cite:
  version = {v1.5},
  url = {https://doi.org/10.5281/zenodo.16752238}
 }
-```
+```text
 
 ---
 

--- a/notebooks/entropic-symbolic-society/README.md
+++ b/notebooks/entropic-symbolic-society/README.md
@@ -49,7 +49,7 @@ If your goal is to **reproduce the NHB analyses**:
 ---
 
 ## Repository Structure (High-level)
-```
+```text
 .
 ├── README.md                 # This file (umbrella overview)
 ├── LICENSE                   # MIT for code; see licensing notes below
@@ -66,7 +66,7 @@ If your goal is to **reproduce the NHB analyses**:
     ├── NHB_main.tex          # NHB LaTeX manuscript (subproject scope)
     ├── sections/             # NHB manuscript sections (subproject scope)
     └── supplementary.tex     # NHB supplement (subproject scope)
-```
+```text
 
 ---
 


### PR DESCRIPTION
## Summary
- loosen markdownlint rules to be non-blocking
- add `text` language to unlabeled code fences across docs

## Testing
- `pipx run pre-commit run --all-files || true` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acd1a2f33c83308e36c9ff8c2249fe